### PR TITLE
made standalone

### DIFF
--- a/Readme.txt
+++ b/Readme.txt
@@ -1,4 +1,4 @@
-
+Added esx support
 Welcome to Tsunami Quality of Life
 
 Welcome to the Tsunami Quality of Life script, I have designed the script to allow auto-restart through txAdmin to bring having restarts more ingame depth.

--- a/client/main.lua
+++ b/client/main.lua
@@ -1,71 +1,29 @@
 -------------------- Strez Tsunami --------------------
-local QBCore = exports['qb-core']:GetCoreObject()
 
 -------------------- Emails --------------------
 
--- Emergency Alert
-RegisterNetEvent('strez:client:SendEmergencyEmail', function(text)
-    Wait(math.random(7000, 13000))
-    TriggerServerEvent('qb-phone:server:sendNewMail', {
-        sender = "City of Los Santos",
-        subject = "Emergency Alert",
-        message = text,
-        button = {}
-    })
-end)
-
--- Announcement Email
-RegisterNetEvent('strez:client:SendAnnouncementEmail', function(text)
-    Wait(math.random(7000, 13000))
-    TriggerServerEvent('qb-phone:server:sendNewMail', {
-        sender = "City of Los Santos",
-        subject = "Announcement",
-        message = text,
-        button = {}
-    })
-    Wait(500)
-end)
-
--------------------- Manual Tsunami Email --------------------
-
--- Manual Warning Email
 RegisterNetEvent('strez:client:TsunamiManual', function(text)
     TriggerEvent('InteractSound_CL:PlayOnOne', 'Alert', 0.1)
     Wait(math.random(7000, 13000))
-    TriggerServerEvent('qb-phone:server:sendNewMail', {
-        sender = 'District of Los Santos',
-        subject = 'Emergency Broadcast',
-        message = 'The National Weather Service has issued a TSUNAMI WARNING for Los Santos, In 15 minutes! Please start heading home or somewhere local for SAFETY!',
-        button = {}
-    })
+    
     Wait(math.random(30000, 60000))
-    TriggerServerEvent('qb-weathersync:server:setWeather', 'THUNDER')
+        TriggerEvent('changeWeather', 'THUNDER')
+        
 end)
 
 -------------------- Auto Restart Tsunami Email --------------------
 
 -- 30 Minutes Reminder
 RegisterNetEvent('strez:client:SendMailTsunamiAuto30', function(text)
-    TriggerServerEvent('qb-phone:server:sendNewMail', {
-        sender = 'Los Santos Weather',
-        subject = 'Weather Forecast',
-        message = 'We\'re happy to report that we have clear skies dominating the forecast, and there is no rain expected in the foreseeable future.',
-        button = {}
-    })
+
     Wait(5000)
-    TriggerServerEvent('qb-weathersync:server:setWeather', 'CLEAR')
+        TriggerEvent('changeWeather', 'CLEAR')
 end)
 
 -- 15 Minutes Reminder
 RegisterNetEvent('strez:client:SendMailTsunamiAuto15', function(text)
-    TriggerServerEvent('qb-phone:server:sendNewMail', {
-        sender = 'Los Santos Weather',
-        subject = 'Weather Update',
-        message = 'We apologize for the inaccurate forecasts earlier, and I understand your concern. It appears that the weather has taken an unexpected turn, and rain is now falling.',
-        button = {}
-    })
     Wait(5000)
-    TriggerServerEvent('qb-weathersync:server:setWeather', 'RAIN')
+                TriggerEvent('changeWeather', 'RAIN')
 end)
 
 
@@ -73,26 +31,30 @@ end)
 RegisterNetEvent('strez:client:SendMailTsunamiAuto5', function(text)
     TriggerEvent('InteractSound_CL:PlayOnOne', 'Alert', 0.1)
     Wait(10000)
-    TriggerServerEvent('qb-phone:server:sendNewMail', {
-        sender = 'Los Santos Weather',
-        subject = 'Emergency Weather',
-        message = 'This is an emergency weather update. A tsunami is predicted to make contact in less than 5 minutes. If you are in a coastal area, it is imperative to take immediate action to move to higher ground and seek safety. Please follow any official alerts, instructions, and evacuation orders issued by local authorities. Stay away from beaches and low-lying areas.',
-        button = {}
-    })
     Wait(5000)
-    TriggerServerEvent('qb-weathersync:server:setWeather', 'THUNDER')
+        TriggerEvent('changeWeather', 'THUNDER')
 end)
 
 -- 1 Minutes Reminder
 RegisterNetEvent('strez:client:SendMailTsunamiAuto1', function(text)
     TriggerEvent('InteractSound_CL:PlayOnOne', 'Alert', 0.1)
     Wait(10000)
-    TriggerServerEvent('qb-phone:server:sendNewMail', {
-        sender = 'Los Santos Weather',
-        subject = 'Emergency Weather',
-        message = 'This is an emergency weather update. A tsunami is imminent. <br> <br> If you are in a coastal area, it is imperative to take immediate action to move to higher ground and seek safety. Please follow any official alerts, instructions, and evacuation orders issued by local authorities. Stay away from beaches and low-lying areas.',
-        button = {}
-    })
-    Wait(5000)
-    TriggerServerEvent('qb-weathersync:server:toggleBlackout')
+ -- need to do blackout
+
+    end)
+
+RegisterNetEvent('changeWeather')
+AddEventHandler('changeWeather', function(weatherType)
+    if IsAllowedToChangeWeather() then
+        SetWeatherTypeNowPersist(weatherType)
+        SetWeatherTypeNow(weatherType)
+        Citizen.Wait(1000) 
+    else
+        TriggerEvent('chatMessage', '^1[Error]^0 You do not have permission to change the weather.')
+    end
 end)
+
+function IsAllowedToChangeWeather()
+    return true
+end
+

--- a/server/main.lua
+++ b/server/main.lua
@@ -1,36 +1,26 @@
--------------------- Strez Tsunami --------------------
-local QBCore = exports['qb-core']:GetCoreObject()
-
--------------------- Email Commands --------------------
-
--- Emergency Email
-QBCore.Commands.Add('emergencyemail', 'Send emergency email to everyone', {{name = 'Email', help = 'Text of Email'}}, true, function(source, args)
+RegisterCommand('emergencyemail', function(source, args, rawCommand)
     local msg = table.concat(args, ' ')
     local len = tonumber(string.len(msg))
     if len <= 255 then
         TriggerClientEvent('strez:client:SendEmergencyEmail', -1, msg)
     else
-        TriggerClientEvent('QBCore:Notify', source, 'Exceeds maximum characters!', 'error')
+        TriggerClientEvent('chatMessage', source, '^1[Error]^0 Exceeds maximum characters!', {255, 0, 0})
     end
-end, 'god')
+end, true)
 
--- Announcement Email
-QBCore.Commands.Add('announcementemail', 'Send announcement email to everyone', {{name = 'Email', help = 'Text of Email'}}, true, function(source, args)
+RegisterCommand('announcementemail', function(source, args, rawCommand)
     local msg = table.concat(args, ' ')
     local len = tonumber(string.len(msg))
     if len <= 255 then
         TriggerClientEvent('strez:client:SendAnnouncementEmail', -1, msg)
     else
-        TriggerClientEvent('QBCore:Notify', source, 'Exceeds maximum characters!', 'error')
+        TriggerClientEvent('chatMessage', source, '^1[Error]^0 Exceeds maximum characters!', {255, 0, 0})
     end
-end, 'god')
+end, true)
+
 
 -------------------- Manual Tsunami Email --------------------
 
--- Manual 15 Minute Tsunami Warning
-QBCore.Commands.Add('tsunamimanual', '15 minute tsuanami warning', {}, true, function(source, args)
-    TriggerClientEvent('strez:client:TsunamiManual', -1)
-end, 'god')
 
 -------------------- Auto Restart Tsunami Email --------------------
 
@@ -41,12 +31,7 @@ AddEventHandler('txAdmin:events:scheduledRestart', function(eventData)
     end
 end)
 
--- 15 Minutes Reminder
-AddEventHandler('txAdmin:events:scheduledRestart', function(eventData)
-    if eventData.secondsRemaining == 900 then
-        TriggerClientEvent('strez:client:SendMailTsunamiAuto15', -1)
-    end
-end)
+
 
 -- 5 Minutes Reminder
 AddEventHandler('txAdmin:events:scheduledRestart', function(eventData)


### PR DESCRIPTION
if you modify the logic below you could remove the need for qbcore and globalize the phone event so people who use lb-phone etc could use it and remove the need for qb-core so all frameworks could use this.